### PR TITLE
Add unit tests, integration tests, and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and Test
+        run: |
+          xcodebuild test \
+            -project StockBar.xcodeproj \
+            -scheme StockBar \
+            -destination 'platform=macOS' \
+            -parallel-testing-enabled NO \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color || true
+
+          # Return the actual xcodebuild exit code, not xcpretty's
+          exit ${PIPESTATUS[0]}

--- a/StockBar.xcodeproj/project.pbxproj
+++ b/StockBar.xcodeproj/project.pbxproj
@@ -19,7 +19,21 @@
 		1938789724D647C8009FA349 /* Trade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1938789624D647C8009FA349 /* Trade.swift */; };
 		19E9000724D73BC600D4D818 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9000624D73BC600D4D818 /* UserData.swift */; };
 		19E9000924D776C400D4D818 /* PreferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9000824D776C400D4D818 /* PreferenceView.swift */; };
+		AA111111000000000000000D /* YahooFinanceDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA111111000000000000000C /* YahooFinanceDecoderTests.swift */; };
+		AA111111000000000000000F /* TradeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA111111000000000000000E /* TradeModelTests.swift */; };
+		AA1111110000000000000011 /* CombineDataFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1111110000000000000010 /* CombineDataFlowTests.swift */; };
+		AA1111110000000000000013 /* YahooFinanceAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1111110000000000000012 /* YahooFinanceAPITests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		AA111111000000000000000A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1919BC00249EAEF000D708F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1919BC07249EAEF000D708F4;
+			remoteInfo = StockBar;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		1919BC08249EAEF000D708F4 /* StockBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StockBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -37,10 +51,22 @@
 		1938789624D647C8009FA349 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		19E9000624D73BC600D4D818 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		19E9000824D776C400D4D818 /* PreferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceView.swift; sourceTree = "<group>"; };
+		AA1111110000000000000001 /* StockBarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StockBarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA111111000000000000000C /* YahooFinanceDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YahooFinanceDecoderTests.swift; sourceTree = "<group>"; };
+		AA111111000000000000000E /* TradeModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeModelTests.swift; sourceTree = "<group>"; };
+		AA1111110000000000000010 /* CombineDataFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDataFlowTests.swift; sourceTree = "<group>"; };
+		AA1111110000000000000012 /* YahooFinanceAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YahooFinanceAPITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		1919BC05249EAEF000D708F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AA1111110000000000000004 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -54,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				1919BC0A249EAEF000D708F4 /* StockBar */,
+				AA111111000000000000000B /* StockBarTests */,
 				1919BC09249EAEF000D708F4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -62,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				1919BC08249EAEF000D708F4 /* StockBar.app */,
+				AA1111110000000000000001 /* StockBarTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -95,6 +123,17 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
+		AA111111000000000000000B /* StockBarTests */ = {
+			isa = PBXGroup;
+			children = (
+				AA111111000000000000000C /* YahooFinanceDecoderTests.swift */,
+				AA111111000000000000000E /* TradeModelTests.swift */,
+				AA1111110000000000000010 /* CombineDataFlowTests.swift */,
+				AA1111110000000000000012 /* YahooFinanceAPITests.swift */,
+			);
+			path = StockBarTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -115,6 +154,23 @@
 			productReference = 1919BC08249EAEF000D708F4 /* StockBar.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AA1111110000000000000002 /* StockBarTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA1111110000000000000006 /* Build configuration list for PBXNativeTarget "StockBarTests" */;
+			buildPhases = (
+				AA1111110000000000000003 /* Sources */,
+				AA1111110000000000000004 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AA1111110000000000000009 /* PBXTargetDependency */,
+			);
+			name = StockBarTests;
+			productName = StockBarTests;
+			productReference = AA1111110000000000000001 /* StockBarTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -127,6 +183,10 @@
 				TargetAttributes = {
 					1919BC07249EAEF000D708F4 = {
 						CreatedOnToolsVersion = 11.5;
+					};
+					AA1111110000000000000002 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 1919BC07249EAEF000D708F4;
 					};
 				};
 			};
@@ -144,6 +204,7 @@
 			projectRoot = "";
 			targets = (
 				1919BC07249EAEF000D708F4 /* StockBar */,
+				AA1111110000000000000002 /* StockBarTests */,
 			);
 		};
 /* End PBXProject section */
@@ -178,7 +239,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AA1111110000000000000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA111111000000000000000D /* YahooFinanceDecoderTests.swift in Sources */,
+				AA111111000000000000000F /* TradeModelTests.swift in Sources */,
+				AA1111110000000000000011 /* CombineDataFlowTests.swift in Sources */,
+				AA1111110000000000000013 /* YahooFinanceAPITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AA1111110000000000000009 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1919BC07249EAEF000D708F4 /* StockBar */;
+			targetProxy = AA111111000000000000000A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		1919BC11249EAEF100D708F4 /* Main.storyboard */ = {
@@ -347,6 +427,36 @@
 			};
 			name = Release;
 		};
+		AA1111110000000000000007 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fhl43211.StockBarTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StockBar.app/Contents/MacOS/StockBar";
+			};
+			name = Debug;
+		};
+		AA1111110000000000000008 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fhl43211.StockBarTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StockBar.app/Contents/MacOS/StockBar";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -364,6 +474,15 @@
 			buildConfigurations = (
 				1919BC19249EAEF100D708F4 /* Debug */,
 				1919BC1A249EAEF100D708F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AA1111110000000000000006 /* Build configuration list for PBXNativeTarget "StockBarTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA1111110000000000000007 /* Debug */,
+				AA1111110000000000000008 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/StockBar.xcodeproj/xcshareddata/xcschemes/StockBar.xcscheme
+++ b/StockBar.xcodeproj/xcshareddata/xcschemes/StockBar.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA1111110000000000000002"
+               BuildableName = "StockBarTests.xctest"
+               BlueprintName = "StockBarTests"
+               ReferencedContainer = "container:StockBar.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/StockBar.xcodeproj/xcshareddata/xcschemes/StockBar.xcscheme
+++ b/StockBar.xcodeproj/xcshareddata/xcschemes/StockBar.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:StockBar.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA1111110000000000000002"
+               BuildableName = "StockBarTests.xctest"
+               BlueprintName = "StockBarTests"
+               ReferencedContainer = "container:StockBar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/StockBarTests/CombineDataFlowTests.swift
+++ b/StockBarTests/CombineDataFlowTests.swift
@@ -1,0 +1,250 @@
+//
+//  CombineDataFlowTests.swift
+//  StockBarTests
+//
+//  Integration tests for the Combine reactive pipeline:
+//  Trade change -> debounce -> filter -> API fetch -> decode -> update realTimeInfo
+//  Uses MockURLProtocol to intercept network requests.
+//
+
+import XCTest
+import Combine
+@testable import StockBar
+
+@available(macOS 11.0, *)
+final class CombineDataFlowTests: XCTestCase {
+
+    var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testRealTimeTradeUpdatesOnPublish() {
+        let mockJSON = Self.makeQuoteJSON(
+            symbol: "AAPL", currency: "USD", price: 175.50, prevClose: 173.00,
+            shortName: "Apple Inc.", timezone: "America/New_York"
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, mockJSON)
+        }
+
+        let rt = RealTimeTrade(
+            trade: Trade(name: "AAPL", position: Position(unitSize: "100", positionAvgCost: "150")),
+            realTimeInfo: TradingInfo()
+        )
+
+        let expectation = XCTestExpectation(description: "RealTimeInfo updated with mock data")
+
+        rt.$realTimeInfo
+            .dropFirst()
+            .sink { info in
+                if !info.currentPrice.isNaN {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        rt.sendTradeToPublisher()
+
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertEqual(rt.realTimeInfo.currentPrice, 175.50, accuracy: 0.01)
+        XCTAssertEqual(rt.realTimeInfo.prevClosePrice, 173.00, accuracy: 0.01)
+        XCTAssertEqual(rt.realTimeInfo.currency, "USD")
+    }
+
+    func testEmptySymbolIsFiltered() {
+        MockURLProtocol.requestHandler = { _ in
+            XCTFail("Should not make a network request for an empty symbol")
+            return (HTTPURLResponse(), Data())
+        }
+
+        let rt = RealTimeTrade(
+            trade: Trade(name: "", position: Position(unitSize: "1", positionAvgCost: "")),
+            realTimeInfo: TradingInfo()
+        )
+
+        rt.sendTradeToPublisher()
+
+        // Inverted expectation: should NOT be fulfilled (i.e. no request made)
+        let noRequest = XCTestExpectation(description: "No network request")
+        noRequest.isInverted = true
+        wait(for: [noRequest], timeout: 2.0)
+    }
+
+    func testAPIErrorReturnsEmptyTradingInfo() {
+        let errorJSON = """
+        { "chart": { "result": null, "error": { "description": "Not Found" } } }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, errorJSON)
+        }
+
+        let rt = RealTimeTrade(
+            trade: Trade(name: "INVALID", position: Position(unitSize: "1", positionAvgCost: "")),
+            realTimeInfo: TradingInfo(currentPrice: 999, prevClosePrice: 999)
+        )
+
+        let expectation = XCTestExpectation(description: "TradingInfo reset on error response")
+
+        rt.$realTimeInfo
+            .dropFirst()
+            .sink { info in
+                if info.currentPrice.isNaN {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        rt.sendTradeToPublisher()
+
+        wait(for: [expectation], timeout: 10.0)
+        XCTAssertTrue(rt.realTimeInfo.currentPrice.isNaN)
+    }
+
+    func testCorrectURLConstruction() {
+        let expectedSymbol = "BTC-USD"
+        let urlChecked = XCTestExpectation(description: "URL contains symbol and interval")
+
+        MockURLProtocol.requestHandler = { request in
+            let urlString = request.url!.absoluteString
+            XCTAssertTrue(urlString.contains(expectedSymbol), "URL should contain \(expectedSymbol)")
+            XCTAssertTrue(urlString.contains("interval=1d"), "URL should contain interval=1d")
+            urlChecked.fulfill()
+
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, "{\"chart\": null}".data(using: .utf8)!)
+        }
+
+        let rt = RealTimeTrade(
+            trade: Trade(name: expectedSymbol, position: Position(unitSize: "1", positionAvgCost: "")),
+            realTimeInfo: TradingInfo()
+        )
+
+        rt.sendTradeToPublisher()
+        wait(for: [urlChecked], timeout: 10.0)
+    }
+
+    func testMultipleSymbolsUpdateIndependently() {
+        let aaplJSON = Self.makeQuoteJSON(
+            symbol: "AAPL", currency: "USD", price: 175.0, prevClose: 173.0,
+            shortName: "Apple Inc.", timezone: "America/New_York"
+        )
+        let btcJSON = Self.makeQuoteJSON(
+            symbol: "BTC-USD", currency: "USD", price: 50000.0, prevClose: 49000.0,
+            shortName: "Bitcoin USD", timezone: "UTC"
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            let urlString = request.url!.absoluteString
+            let data = urlString.contains("BTC-USD") ? btcJSON : aaplJSON
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, data)
+        }
+
+        let aapl = RealTimeTrade(
+            trade: Trade(name: "AAPL", position: Position(unitSize: "10", positionAvgCost: "150")),
+            realTimeInfo: TradingInfo()
+        )
+        let btc = RealTimeTrade(
+            trade: Trade(name: "BTC-USD", position: Position(unitSize: "0.5", positionAvgCost: "30000")),
+            realTimeInfo: TradingInfo()
+        )
+
+        let aaplExpectation = XCTestExpectation(description: "AAPL updated")
+        let btcExpectation = XCTestExpectation(description: "BTC updated")
+
+        aapl.$realTimeInfo
+            .dropFirst()
+            .sink { info in if !info.currentPrice.isNaN { aaplExpectation.fulfill() } }
+            .store(in: &cancellables)
+
+        btc.$realTimeInfo
+            .dropFirst()
+            .sink { info in if !info.currentPrice.isNaN { btcExpectation.fulfill() } }
+            .store(in: &cancellables)
+
+        aapl.sendTradeToPublisher()
+        btc.sendTradeToPublisher()
+
+        wait(for: [aaplExpectation, btcExpectation], timeout: 10.0)
+
+        XCTAssertEqual(aapl.realTimeInfo.currentPrice, 175.0, accuracy: 0.01)
+        XCTAssertEqual(btc.realTimeInfo.currentPrice, 50000.0, accuracy: 0.01)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeQuoteJSON(
+        symbol: String, currency: String, price: Double, prevClose: Double,
+        shortName: String, timezone: String
+    ) -> Data {
+        return """
+        {
+            "chart": {
+                "result": [{
+                    "meta": {
+                        "currency": "\(currency)",
+                        "symbol": "\(symbol)",
+                        "shortName": "\(shortName)",
+                        "regularMarketTime": 1679000000,
+                        "exchangeTimezoneName": "\(timezone)",
+                        "regularMarketPrice": \(price),
+                        "chartPreviousClose": \(prevClose)
+                    }
+                }],
+                "error": null
+            }
+        }
+        """.data(using: .utf8)!
+    }
+}
+
+// MARK: - Mock URL Protocol
+
+class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/StockBarTests/TradeModelTests.swift
+++ b/StockBarTests/TradeModelTests.swift
@@ -1,0 +1,217 @@
+//
+//  TradeModelTests.swift
+//  StockBarTests
+//
+//  Tests for core domain models (Trade, Position, TradingInfo),
+//  P&L calculations, and data persistence via UserDefaults.
+//
+
+import XCTest
+@testable import StockBar
+
+final class TradeModelTests: XCTestCase {
+
+    // MARK: - Position Validation
+
+    func testPositionValidNumericInput() {
+        let pos = Position(unitSize: "100", positionAvgCost: "150.50")
+        XCTAssertEqual(pos.unitSize, 100.0)
+        XCTAssertEqual(pos.positionAvgCost, 150.50)
+    }
+
+    func testPositionInvalidUnitSizeDefaultsToOne() {
+        let pos = Position(unitSize: "abc", positionAvgCost: "150.00")
+        XCTAssertEqual(pos.unitSize, 1.0)
+        XCTAssertEqual(pos.unitSizeString, "1")
+    }
+
+    func testPositionEmptyAvgCostIsNaN() {
+        let pos = Position(unitSize: "10", positionAvgCost: "")
+        XCTAssertTrue(pos.positionAvgCost.isNaN)
+    }
+
+    func testPositionUnitSizeSetterValidation() {
+        var pos = Position(unitSize: "10", positionAvgCost: "100")
+        pos.unitSizeString = "not_a_number"
+        XCTAssertEqual(pos.unitSizeString, "1", "Invalid input should reset to 1")
+        pos.unitSizeString = "50"
+        XCTAssertEqual(pos.unitSizeString, "50")
+        XCTAssertEqual(pos.unitSize, 50.0)
+    }
+
+    func testPositionFractionalUnits() {
+        let pos = Position(unitSize: "0.5", positionAvgCost: "40000")
+        XCTAssertEqual(pos.unitSize, 0.5)
+        XCTAssertEqual(pos.positionAvgCost, 40000.0)
+    }
+
+    // MARK: - Trade Encode/Decode (Persistence)
+
+    func testTradeEncodeDecode() throws {
+        let original = Trade(name: "AAPL", position: Position(unitSize: "100", positionAvgCost: "150.00"))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Trade.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testMultipleTradesEncodeDecode() throws {
+        let trades = [
+            Trade(name: "AAPL", position: Position(unitSize: "100", positionAvgCost: "150.00")),
+            Trade(name: "BTC-USD", position: Position(unitSize: "0.5", positionAvgCost: "40000")),
+            Trade(name: "USDJPY=X", position: Position(unitSize: "10000", positionAvgCost: "110")),
+        ]
+        let data = try JSONEncoder().encode(trades)
+        let decoded = try JSONDecoder().decode([Trade].self, from: data)
+        XCTAssertEqual(decoded, trades)
+    }
+
+    // MARK: - TradingInfo Formatting
+
+    func testTradingInfoPriceFormat() {
+        let info = TradingInfo(currentPrice: 150.256, prevClosePrice: 148.5, currency: "USD")
+        XCTAssertEqual(info.getPrice(), "USD 150.256")
+    }
+
+    func testTradingInfoChangePositive() {
+        let info = TradingInfo(currentPrice: 150.25, prevClosePrice: 148.50)
+        XCTAssertEqual(info.getChange(), "+1.75")
+    }
+
+    func testTradingInfoChangeNegative() {
+        let info = TradingInfo(currentPrice: 146.50, prevClosePrice: 148.50)
+        XCTAssertEqual(info.getChange(), "-2.00")
+    }
+
+    func testTradingInfoChangePct() {
+        let info = TradingInfo(currentPrice: 150.0, prevClosePrice: 100.0)
+        XCTAssertEqual(info.getChangePct(), "+50.0000%")
+    }
+
+    func testTradingInfoNilCurrencyFallback() {
+        let info = TradingInfo(currentPrice: 100.0, prevClosePrice: 99.0, currency: nil)
+        XCTAssertTrue(info.getPrice().hasPrefix("Price"))
+    }
+
+    // MARK: - P&L Calculations
+
+    func testDailyPNLPositive() {
+        let info = TradingInfo(currentPrice: 152.0, prevClosePrice: 150.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "140.00")
+        XCTAssertEqual(dailyPNLNumber(info, pos), 200.0, accuracy: 0.01)
+    }
+
+    func testDailyPNLNegative() {
+        let info = TradingInfo(currentPrice: 148.0, prevClosePrice: 150.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "140.00")
+        XCTAssertEqual(dailyPNLNumber(info, pos), -200.0, accuracy: 0.01)
+    }
+
+    func testDailyPNLStringFormat() {
+        let info = TradingInfo(currentPrice: 152.0, prevClosePrice: 150.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "140.00")
+        let result = dailyPNL(info, pos)
+        XCTAssertTrue(result.contains("Daily PnL"))
+        XCTAssertTrue(result.contains("USD"))
+        XCTAssertTrue(result.contains("+200.00"))
+    }
+
+    func testDailyPNLFractionalShares() {
+        let info = TradingInfo(currentPrice: 50000.0, prevClosePrice: 49000.0, currency: "USD")
+        let pos = Position(unitSize: "0.5", positionAvgCost: "30000")
+        XCTAssertEqual(dailyPNLNumber(info, pos), 500.0, accuracy: 0.01)
+    }
+
+    func testDailyPNLZeroChange() {
+        let info = TradingInfo(currentPrice: 100.0, prevClosePrice: 100.0, currency: "USD")
+        let pos = Position(unitSize: "50", positionAvgCost: "90")
+        XCTAssertEqual(dailyPNLNumber(info, pos), 0.0, accuracy: 0.01)
+    }
+
+    // MARK: - Helper Functions
+
+    func testEmptyTrades() {
+        let trades = emptyTrades(size: 3)
+        XCTAssertEqual(trades.count, 3)
+        for trade in trades {
+            XCTAssertEqual(trade.name, "")
+            XCTAssertEqual(trade.position.unitSize, 1.0)
+        }
+    }
+
+    func testEmptyRealTimeTrade() {
+        let rt = emptyRealTimeTrade()
+        XCTAssertEqual(rt.trade.name, "")
+        XCTAssertTrue(rt.realTimeInfo.currentPrice.isNaN)
+    }
+
+    // MARK: - DataModel Persistence
+
+    private let testKey = "usertrades"
+    private var savedData: Data?
+
+    override func setUp() {
+        super.setUp()
+        savedData = UserDefaults.standard.data(forKey: testKey)
+    }
+
+    override func tearDown() {
+        if let savedData = savedData {
+            UserDefaults.standard.set(savedData, forKey: testKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: testKey)
+        }
+        super.tearDown()
+    }
+
+    func testDataModelLoadsFromUserDefaults() throws {
+        let trades = [
+            Trade(name: "AAPL", position: Position(unitSize: "100", positionAvgCost: "150.00")),
+            Trade(name: "GOOG", position: Position(unitSize: "50", positionAvgCost: "2800.00")),
+        ]
+        let data = try JSONEncoder().encode(trades)
+        UserDefaults.standard.set(data, forKey: testKey)
+
+        let model = DataModel()
+
+        XCTAssertEqual(model.realTimeTrades.count, 2)
+        XCTAssertEqual(model.realTimeTrades[0].trade.name, "AAPL")
+        XCTAssertEqual(model.realTimeTrades[0].trade.position.unitSize, 100.0)
+        XCTAssertEqual(model.realTimeTrades[1].trade.name, "GOOG")
+    }
+
+    func testDataModelWithNoSavedData() {
+        UserDefaults.standard.removeObject(forKey: testKey)
+
+        let model = DataModel()
+
+        XCTAssertEqual(model.realTimeTrades.count, 1)
+        XCTAssertEqual(model.realTimeTrades[0].trade.name, "")
+    }
+
+    func testDataModelWithCorruptedData() {
+        UserDefaults.standard.set("not json".data(using: .utf8), forKey: testKey)
+
+        let model = DataModel()
+
+        XCTAssertEqual(model.realTimeTrades.count, 1, "Corrupted data should fall back to defaults")
+        XCTAssertEqual(model.realTimeTrades[0].trade.name, "")
+    }
+
+    func testSaveAndReloadRoundTrip() throws {
+        let trades = [
+            Trade(name: "BTC-USD", position: Position(unitSize: "0.5", positionAvgCost: "40000")),
+            Trade(name: "USDJPY=X", position: Position(unitSize: "10000", positionAvgCost: "110")),
+        ]
+
+        let data = try JSONEncoder().encode(trades)
+        UserDefaults.standard.set(data, forKey: testKey)
+
+        let model = DataModel()
+
+        XCTAssertEqual(model.realTimeTrades.count, 2)
+        XCTAssertEqual(model.realTimeTrades[0].trade.name, "BTC-USD")
+        XCTAssertEqual(model.realTimeTrades[0].trade.position.unitSize, 0.5)
+        XCTAssertEqual(model.realTimeTrades[1].trade.name, "USDJPY=X")
+        XCTAssertEqual(model.realTimeTrades[1].trade.position.unitSize, 10000.0)
+    }
+}

--- a/StockBarTests/YahooFinanceAPITests.swift
+++ b/StockBarTests/YahooFinanceAPITests.swift
@@ -1,0 +1,105 @@
+//
+//  YahooFinanceAPITests.swift
+//  StockBarTests
+//
+//  Integration tests that hit the live Yahoo Finance API.
+//  These validate the full end-to-end flow: network request -> JSON decode -> model update.
+//  Tests handle API unavailability gracefully (no hard failure on network issues).
+//
+
+import XCTest
+import Combine
+@testable import StockBar
+
+final class YahooFinanceAPITests: XCTestCase {
+
+    var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testFetchRealStockQuote() {
+        let expectation = XCTestExpectation(description: "Fetch AAPL quote from Yahoo Finance")
+
+        let url = URL(string: "https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d")!
+
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map(\.data)
+            .decode(type: YahooFinanceQuote.self, decoder: JSONDecoder())
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    print("Live API test (AAPL) skipped due to: \(error.localizedDescription)")
+                    expectation.fulfill()
+                }
+            }, receiveValue: { quote in
+                if let meta = quote.chart?.result?.first?.meta {
+                    XCTAssertEqual(meta.symbol, "AAPL")
+                    XCTAssertEqual(meta.currency, "USD")
+                    XCTAssertGreaterThan(meta.regularMarketPrice, 0)
+                    XCTAssertFalse(meta.shortName.isEmpty)
+                    XCTAssertFalse(meta.exchangeTimezoneName.isEmpty)
+                }
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 30.0)
+    }
+
+    func testFetchCurrencyPairQuote() {
+        let expectation = XCTestExpectation(description: "Fetch USDJPY=X quote from Yahoo Finance")
+
+        let url = URL(string: "https://query1.finance.yahoo.com/v8/finance/chart/USDJPY%3DX?interval=1d")!
+
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map(\.data)
+            .decode(type: YahooFinanceQuote.self, decoder: JSONDecoder())
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    print("Live API test (USDJPY=X) skipped due to: \(error.localizedDescription)")
+                    expectation.fulfill()
+                }
+            }, receiveValue: { quote in
+                if let meta = quote.chart?.result?.first?.meta {
+                    XCTAssertGreaterThan(meta.regularMarketPrice, 0)
+                }
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 30.0)
+    }
+
+    @available(macOS 11.0, *)
+    func testEndToEndRealTimeTradeWithLiveAPI() {
+        let rt = RealTimeTrade(
+            trade: Trade(name: "AAPL", position: Position(unitSize: "10", positionAvgCost: "150")),
+            realTimeInfo: TradingInfo()
+        )
+
+        let expectation = XCTestExpectation(description: "Live API updates RealTimeTrade end-to-end")
+
+        rt.$realTimeInfo
+            .dropFirst()
+            .sink { info in
+                // Fulfill on any update (including error-reset to NaN)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        rt.sendTradeToPublisher()
+
+        wait(for: [expectation], timeout: 30.0)
+
+        // Only assert if we got valid data (API might be unavailable)
+        if !rt.realTimeInfo.currentPrice.isNaN {
+            XCTAssertGreaterThan(rt.realTimeInfo.currentPrice, 0)
+            XCTAssertEqual(rt.realTimeInfo.currency, "USD")
+            XCTAssertFalse(rt.realTimeInfo.shortName.isEmpty)
+        }
+    }
+}

--- a/StockBarTests/YahooFinanceDecoderTests.swift
+++ b/StockBarTests/YahooFinanceDecoderTests.swift
@@ -1,0 +1,185 @@
+//
+//  YahooFinanceDecoderTests.swift
+//  StockBarTests
+//
+//  Tests for Yahoo Finance API JSON response decoding - the most critical path.
+//  If decoding breaks, the entire app is non-functional.
+//
+
+import XCTest
+@testable import StockBar
+
+final class YahooFinanceDecoderTests: XCTestCase {
+
+    // MARK: - JSON Decoding
+
+    func testDecodeValidResponse() throws {
+        let json = """
+        {
+            "chart": {
+                "result": [{
+                    "meta": {
+                        "currency": "USD",
+                        "symbol": "AAPL",
+                        "shortName": "Apple Inc.",
+                        "regularMarketTime": 1679000000,
+                        "exchangeTimezoneName": "America/New_York",
+                        "regularMarketPrice": 150.25,
+                        "chartPreviousClose": 148.50
+                    }
+                }],
+                "error": null
+            }
+        }
+        """.data(using: .utf8)!
+
+        let quote = try JSONDecoder().decode(YahooFinanceQuote.self, from: json)
+
+        let meta = try XCTUnwrap(quote.chart?.result?.first?.meta)
+        XCTAssertEqual(meta.symbol, "AAPL")
+        XCTAssertEqual(meta.currency, "USD")
+        XCTAssertEqual(meta.shortName, "Apple Inc.")
+        XCTAssertEqual(meta.regularMarketPrice, 150.25)
+        XCTAssertEqual(meta.regularMarketPreviousClose, 148.50)
+        XCTAssertEqual(meta.regularMarketTime, 1679000000)
+        XCTAssertEqual(meta.exchangeTimezoneName, "America/New_York")
+    }
+
+    func testDecodeErrorResponse() throws {
+        let json = """
+        {
+            "chart": {
+                "result": null,
+                "error": {
+                    "description": "No data found, symbol may be delisted"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let quote = try JSONDecoder().decode(YahooFinanceQuote.self, from: json)
+
+        XCTAssertNil(quote.chart?.result)
+        XCTAssertEqual(quote.chart?.error?.description, "No data found, symbol may be delisted")
+    }
+
+    func testDecodeNullChart() throws {
+        let json = """
+        { "chart": null }
+        """.data(using: .utf8)!
+
+        let quote = try JSONDecoder().decode(YahooFinanceQuote.self, from: json)
+        XCTAssertNil(quote.chart)
+    }
+
+    func testDecodeWithoutChartPreviousClose() throws {
+        let json = """
+        {
+            "chart": {
+                "result": [{
+                    "meta": {
+                        "currency": "JPY",
+                        "symbol": "9626.T",
+                        "shortName": "Some Corp",
+                        "regularMarketTime": 1679000000,
+                        "exchangeTimezoneName": "Asia/Tokyo",
+                        "regularMarketPrice": 5000.0
+                    }
+                }],
+                "error": null
+            }
+        }
+        """.data(using: .utf8)!
+
+        let quote = try JSONDecoder().decode(YahooFinanceQuote.self, from: json)
+        let meta = try XCTUnwrap(quote.chart?.result?.first?.meta)
+
+        XCTAssertNil(meta.chartPreviousClose)
+        XCTAssertEqual(meta.regularMarketPreviousClose, 0.0,
+                       "Missing chartPreviousClose should default to 0.0")
+    }
+
+    func testDecodeMultipleResults() throws {
+        let json = """
+        {
+            "chart": {
+                "result": [
+                    {
+                        "meta": {
+                            "currency": "USD",
+                            "symbol": "AAPL",
+                            "shortName": "Apple Inc.",
+                            "regularMarketTime": 1679000000,
+                            "exchangeTimezoneName": "America/New_York",
+                            "regularMarketPrice": 150.25,
+                            "chartPreviousClose": 148.50
+                        }
+                    },
+                    {
+                        "meta": {
+                            "currency": "USD",
+                            "symbol": "GOOG",
+                            "shortName": "Alphabet Inc.",
+                            "regularMarketTime": 1679000000,
+                            "exchangeTimezoneName": "America/New_York",
+                            "regularMarketPrice": 2800.00,
+                            "chartPreviousClose": 2750.00
+                        }
+                    }
+                ],
+                "error": null
+            }
+        }
+        """.data(using: .utf8)!
+
+        let quote = try JSONDecoder().decode(YahooFinanceQuote.self, from: json)
+        XCTAssertEqual(quote.chart?.result?.count, 2)
+        XCTAssertEqual(quote.chart?.result?[0].meta.symbol, "AAPL")
+        XCTAssertEqual(quote.chart?.result?[1].meta.symbol, "GOOG")
+    }
+
+    // MARK: - Meta Formatting
+
+    func testMetaPriceFormat() throws {
+        let meta = try makeMeta(price: 150.25, prevClose: 148.50, currency: "USD")
+        XCTAssertEqual(meta.getPrice(), "USD 150.25")
+    }
+
+    func testMetaChangePositive() throws {
+        let meta = try makeMeta(price: 150.25, prevClose: 148.50, currency: "USD")
+        XCTAssertEqual(meta.getChange(), "+1.75")
+    }
+
+    func testMetaChangeNegative() throws {
+        let meta = try makeMeta(price: 146.50, prevClose: 148.50, currency: "USD")
+        XCTAssertEqual(meta.getChange(), "-2.00")
+    }
+
+    func testMetaChangePct() throws {
+        let meta = try makeMeta(price: 150.0, prevClose: 100.0, currency: "USD")
+        XCTAssertEqual(meta.getChangePct(), "+50.0000%")
+    }
+
+    func testMetaNilCurrencyFallback() throws {
+        let meta = try makeMeta(price: 100.0, prevClose: 99.0, currency: nil)
+        XCTAssertTrue(meta.getPrice().hasPrefix("Price"))
+    }
+
+    // MARK: - Helpers
+
+    private func makeMeta(price: Double, prevClose: Double, currency: String?) throws -> Meta {
+        var jsonDict: [String: Any] = [
+            "symbol": "TEST",
+            "shortName": "Test",
+            "regularMarketTime": 1679000000,
+            "exchangeTimezoneName": "America/New_York",
+            "regularMarketPrice": price,
+            "chartPreviousClose": prevClose
+        ]
+        if let currency = currency {
+            jsonDict["currency"] = currency
+        }
+        let data = try JSONSerialization.data(withJSONObject: jsonDict)
+        return try JSONDecoder().decode(Meta.self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
- Add **41 tests** across 4 test suites covering all key features and data flow
- Add `StockBarTests` Xcode target with scheme integration
- Add GitHub Actions CI workflow (`.github/workflows/tests.yml`)

### Test Suites
| Suite | Tests | Coverage |
|-------|-------|----------|
| **YahooFinanceDecoderTests** | 10 | JSON decoding (valid, error, null, missing fields); Meta formatting |
| **TradeModelTests** | 23 | Position validation, Trade encode/decode, TradingInfo formatting, P&L calculations, DataModel persistence |
| **CombineDataFlowTests** | 5 | Reactive pipeline integration with MockURLProtocol |
| **YahooFinanceAPITests** | 3 | Live Yahoo Finance API end-to-end |

## Test plan
- [x] All 41 tests pass locally via `xcodebuild test`
- [x] Tests runnable from Xcode UI (Cmd+U)
- [ ] CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)