### PR TITLE
Refactor structure, fix bugs, and reduce network traffic

### DIFF
--- a/StockBar/Data/Trade.swift
+++ b/StockBar/Data/Trade.swift
@@ -46,6 +46,29 @@ struct Position : Codable, Equatable {
     
 }
 
+// MARK: - P&L Calculations
+
+func dailyPNLNumber(_ tradingInfo: TradingInfo, _ position: Position)->Double {
+    return (tradingInfo.currentPrice - tradingInfo.prevClosePrice)*position.unitSize
+}
+func dailyPNL(_ tradingInfo: TradingInfo, _ position: Position)->String {
+    let pnlString = String(format: "%+.2f", dailyPNLNumber(tradingInfo, position))
+    return "Daily PnL: " + (tradingInfo.currency ?? "") + " " + pnlString
+}
+func totalPNL(_ tradingInfo: TradingInfo, _ position: Position)->String {
+    let pnl = (tradingInfo.currentPrice - position.positionAvgCost)*position.unitSize
+    let pnlString = String(format: "%+.2f", pnl)
+    return "Total PnL: " + (tradingInfo.currency ?? "") + " " + pnlString
+}
+func totalPositionCost(_ tradingInfo: TradingInfo, _ position: Position)->String {
+    return "Position Cost: " + (tradingInfo.currency ?? "") + " " + String(format: "%.2f", position.unitSize*position.positionAvgCost)
+}
+func currentPositionValue(_ tradingInfo: TradingInfo, _ position: Position)->String {
+    let positionValue = tradingInfo.currentPrice*position.unitSize
+    let positionString = String(format: "%.2f", positionValue)
+    return "Market Value: " + (tradingInfo.currency ?? "") + " " + positionString
+}
+
 struct TradingInfo {
     var currentPrice : Double = .nan
     var prevClosePrice : Double = .nan
@@ -64,6 +87,7 @@ struct TradingInfo {
         return String(format: "%+.4f",currentPrice - prevClosePrice)
     }
     func getChangePct()->String {
+        guard prevClosePrice != 0 else { return "+0.0000%" }
         return String(format: "%+.4f", 100*(currentPrice - prevClosePrice)/prevClosePrice)+"%"
     }
     func getTimeInfo()->String {

--- a/StockBar/Data/UserData.swift
+++ b/StockBar/Data/UserData.swift
@@ -14,12 +14,14 @@ import Combine
 // Real-time trading info fetched from URLSession and updates RealTimeTrading,
 // then reflected on NSStatusItem.
 class DataModel: ObservableObject {
+    static let userTradesKey = "usertrades"
+
     private let decoder = JSONDecoder()
-    
+
     @Published var realTimeTrades: [RealTimeTrade]
-    
+
     init() {
-        let data = UserDefaults.standard.data(forKey: "usertrades") ?? Data()
+        let data = UserDefaults.standard.data(forKey: Self.userTradesKey) ?? Data()
         let trades = (try? decoder.decode([Trade].self, from: data)) ?? emptyTrades(size: 1)
         self.realTimeTrades = trades.map {
             RealTimeTrade(trade: $0, realTimeInfo: TradingInfo())
@@ -31,8 +33,6 @@ class RealTimeTrade: ObservableObject, Identifiable {
     let id = UUID()
     
     static let apiBaseURL = "https://query1.finance.yahoo.com/v8/finance/chart/"
-    static let emptyQueryURL = URL(string: apiBaseURL)!
-    
     @Published var trade: Trade
     @Published var realTimeInfo: TradingInfo
     
@@ -46,12 +46,9 @@ class RealTimeTrade: ObservableObject, Identifiable {
     init(trade: Trade, realTimeInfo: TradingInfo) {
         self.trade = trade
         self.realTimeInfo = realTimeInfo
-        
+
         if #available(macOS 11.0, *) {
             initCancellable()
-        } else {
-            // fallback or no-op for older versions
-            // Optionally log or handle gracefully here
         }
     }
     
@@ -69,9 +66,6 @@ class RealTimeTrade: ObservableObject, Identifiable {
         isCancelled = false
         
         cancellable = sharedPassThroughTrade
-            .merge(with: $trade
-                .debounce(for: .seconds(1), scheduler: RunLoop.main)
-                .removeDuplicates(by: { $0.name == $1.name }))
             .filter { !$0.name.isEmpty }
             .setFailureType(to: URLError.self)
             .flatMap(maxPublishers: .max(1)) { singleTrade -> AnyPublisher<YahooFinanceQuote, Never> in

--- a/StockBar/Data/YahooFinanceDecoder.swift
+++ b/StockBar/Data/YahooFinanceDecoder.swift
@@ -12,7 +12,7 @@ struct YahooFinanceQuote: Codable {
 
 struct Chart: Codable {
     let result: [ChartResult]?
-    let error: Error?
+    let error: ChartError?
 }
 
 struct ChartResult: Codable {
@@ -28,37 +28,12 @@ struct Meta: Codable {
     let regularMarketPrice: Double
     let chartPreviousClose: Double?
     
-    enum CodingKeys: String, CodingKey {
-        case currency, symbol, shortName, regularMarketTime, exchangeTimezoneName, regularMarketPrice, chartPreviousClose
-    }
-    
     var regularMarketPreviousClose: Double {
         return chartPreviousClose ?? 0.0
     }
-    
-    func getPrice()->String {
-        return (currency ?? "Price") + " " + String(format: "%.2f", regularMarketPrice)
-    }
-    func getChange()->String {
-        return String(format: "%+.2f",regularMarketPrice - regularMarketPreviousClose)
-    }
-    func getLongChange()->String {
-        return String(format: "%+.4f",regularMarketPrice - regularMarketPreviousClose)
-    }
-    func getChangePct()->String {
-        return String(format: "%+.4f", 100*(regularMarketPrice - regularMarketPreviousClose)/regularMarketPreviousClose)+"%"
-    }
-    func getTimeInfo()->String {
-        let date = Date(timeIntervalSince1970: TimeInterval(regularMarketTime))
-        let tradeTimeZone = TimeZone(identifier: exchangeTimezoneName)
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm zzz"
-        dateFormatter.timeZone = tradeTimeZone
-        return dateFormatter.string(from: date)
-    }
 }
 
-struct Error: Codable {
+struct ChartError: Codable {
     let description: String
 }
 

--- a/StockBar/PreferenceViewController.swift
+++ b/StockBar/PreferenceViewController.swift
@@ -20,12 +20,16 @@ class PreferenceHostingController : NSHostingController<PreferenceView> {
     override func viewWillDisappear() {
         super.viewWillDisappear()
         saveNewPrefs()
+        // Refresh all symbols when preferences close, since typing no longer triggers API calls
+        data.realTimeTrades.forEach { $0.sendTradeToPublisher() }
     }
     func saveNewPrefs() {
-        let trades = data.realTimeTrades.map {
-            $0.trade
+        do {
+            let trades = data.realTimeTrades.map { $0.trade }
+            let encodedData = try JSONEncoder().encode(trades)
+            UserDefaults.standard.set(encodedData, forKey: DataModel.userTradesKey)
+        } catch {
+            print("Failed to save preferences: \(error.localizedDescription)")
         }
-        let encodedData : Data = try! JSONEncoder().encode(trades)
-        UserDefaults.standard.set( encodedData, forKey: "usertrades")
     }
 }

--- a/StockBar/StockMenuBarController.swift
+++ b/StockBar/StockMenuBarController.swift
@@ -15,7 +15,6 @@ class StockMenuBarController {
         self.statusBar = StockStatusBar()
         self.prefPopover = PreferencePopover(data: data)
         constructMainItem()
-        self.timer = Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(sendAllTradesToSubscriber),                                                                              userInfo: nil, repeats: true)
         // Every time the vector of $realTimeTrades changes (e.g. a new symbol is inserted anywhere or a symbol is deleted),
         //  this resets all the symbol items of the menubar
         self.cancellables = self.data.$realTimeTrades
@@ -23,6 +22,8 @@ class StockMenuBarController {
             .sink { [weak self] realTimeTrades in
                 self?.updateSymbolItemsFromUserData(realTimeTrades: realTimeTrades)
         }
+        // Fetch immediately on launch, which also starts the 60s refresh timer
+        sendAllTradesToSubscriber()
     }
     private var cancellables : AnyCancellable?
     private let statusBar : StockStatusBar
@@ -52,6 +53,11 @@ extension StockMenuBarController {
     // This happens either when manually pressing the Refresh button
     // or every 60 seconds specified in StockMenuBarController.timer
     @objc private func sendAllTradesToSubscriber() {
+        // Reset timer so manual refresh and timer-triggered refresh don't overlap
+        timer.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            self?.sendAllTradesToSubscriber()
+        }
         self.data.realTimeTrades.forEach { each in
             each.sendTradeToPublisher()
         }
@@ -65,7 +71,7 @@ extension StockMenuBarController {
     }
 
     func showPopover(sender: Any?) {
-        if let button = self.statusBar.mainItem()?.button {
+        if let button = self.statusBar.mainItem().button {
             prefPopover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
             NSApp.activate(ignoringOtherApps: true)
         }

--- a/StockBar/StockStatusBar.swift
+++ b/StockBar/StockStatusBar.swift
@@ -8,17 +8,20 @@ import Foundation
 import Combine
 import Cocoa
 
-class StockStatusBar: NSStatusBar {
-    override init() {
+class StockStatusBar {
+    private let mainStatusItem: NSStatusItem
+    private var symbolStatusItems: [StockStatusItemController] = []
+
+    init() {
         mainStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        mainStatusItem?.button?.title = "StockBar"
+        mainStatusItem.button?.title = "StockBar"
     }
     func constructMainItemMenu(items : [NSMenuItem]) {
         let menu = NSMenu()
         for item in items {
             menu.addItem(item)
         }
-        mainStatusItem?.menu = menu
+        mainStatusItem.menu = menu
     }
     func removeAllSymbolItems() {
         symbolStatusItems.removeAll()
@@ -26,11 +29,9 @@ class StockStatusBar: NSStatusBar {
     func constructSymbolItem(from realTimeTrade : RealTimeTrade) {
         symbolStatusItems.append(StockStatusItemController(realTimeTrade: realTimeTrade))
     }
-    func mainItem() -> NSStatusItem? {
+    func mainItem() -> NSStatusItem {
         return mainStatusItem
     }
-    private var mainStatusItem : NSStatusItem?
-    private var symbolStatusItems : [StockStatusItemController] = []
 }
 
 class StockStatusItemController {

--- a/StockBar/SymbolMenu.swift
+++ b/StockBar/SymbolMenu.swift
@@ -5,26 +5,6 @@
 //  Created by Hongliang Fan on 2020-06-20.
 
 import Cocoa
-func dailyPNLNumber(_ tradingInfo: TradingInfo, _ position: Position)->Double {
-    return (tradingInfo.currentPrice - tradingInfo.prevClosePrice)*position.unitSize
-}
-func dailyPNL(_ tradingInfo: TradingInfo, _ position: Position)->String {
-    let pnlString = String(format: "%+.2f", dailyPNLNumber(tradingInfo, position))
-    return "Daily PnL: " + (tradingInfo.currency ?? "") + " " + pnlString
-}
-fileprivate func totalPNL(_ tradingInfo: TradingInfo, _ position: Position)->String {
-    let pnl = (tradingInfo.currentPrice - position.positionAvgCost)*position.unitSize
-    let pnlString = String(format: "%+.2f", pnl)
-    return "Total PnL: " + (tradingInfo.currency ?? "") + " " + pnlString
-}
-fileprivate func totalPositionCost(_ tradingInfo: TradingInfo, _ position: Position)->String {
-    return "Position Cost: " + (tradingInfo.currency ?? "") + " " + String(format: "%.2f", position.unitSize*position.positionAvgCost)
-}
-fileprivate func currentPositionValue(_ tradingInfo: TradingInfo, _ position: Position)->String {
-    let positionValue = tradingInfo.currentPrice*position.unitSize
-    let positionString = String(format: "%.2f", positionValue)
-    return "Market Value: " + (tradingInfo.currency ?? "") + " " + positionString
-}
 
 final class SymbolMenu: NSMenu {
     init(tradingInfo: TradingInfo, position: Position) {

--- a/StockBarTests/TradeModelTests.swift
+++ b/StockBarTests/TradeModelTests.swift
@@ -127,6 +127,51 @@ final class TradeModelTests: XCTestCase {
         XCTAssertEqual(dailyPNLNumber(info, pos), 0.0, accuracy: 0.01)
     }
 
+    // MARK: - Total P&L
+
+    func testTotalPNLProfit() {
+        let info = TradingInfo(currentPrice: 180.0, prevClosePrice: 175.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "150.00")
+        let result = totalPNL(info, pos)
+        XCTAssertTrue(result.contains("Total PnL"))
+        XCTAssertTrue(result.contains("USD"))
+        XCTAssertTrue(result.contains("+3000.00"))
+    }
+
+    func testTotalPNLLoss() {
+        let info = TradingInfo(currentPrice: 140.0, prevClosePrice: 145.0, currency: "USD")
+        let pos = Position(unitSize: "50", positionAvgCost: "160.00")
+        let result = totalPNL(info, pos)
+        XCTAssertTrue(result.contains("-1000.00"))
+    }
+
+    // MARK: - Position Cost & Market Value
+
+    func testTotalPositionCost() {
+        let info = TradingInfo(currentPrice: 180.0, prevClosePrice: 175.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "150.00")
+        let result = totalPositionCost(info, pos)
+        XCTAssertTrue(result.contains("Position Cost"))
+        XCTAssertTrue(result.contains("USD"))
+        XCTAssertTrue(result.contains("15000.00"))
+    }
+
+    func testCurrentPositionValue() {
+        let info = TradingInfo(currentPrice: 180.0, prevClosePrice: 175.0, currency: "USD")
+        let pos = Position(unitSize: "100", positionAvgCost: "150.00")
+        let result = currentPositionValue(info, pos)
+        XCTAssertTrue(result.contains("Market Value"))
+        XCTAssertTrue(result.contains("USD"))
+        XCTAssertTrue(result.contains("18000.00"))
+    }
+
+    func testCurrentPositionValueFractionalShares() {
+        let info = TradingInfo(currentPrice: 50000.0, prevClosePrice: 49000.0, currency: "USD")
+        let pos = Position(unitSize: "0.5", positionAvgCost: "30000")
+        let result = currentPositionValue(info, pos)
+        XCTAssertTrue(result.contains("25000.00"))
+    }
+
     // MARK: - Helper Functions
 
     func testEmptyTrades() {
@@ -146,7 +191,7 @@ final class TradeModelTests: XCTestCase {
 
     // MARK: - DataModel Persistence
 
-    private let testKey = "usertrades"
+    private let testKey = DataModel.userTradesKey
     private var savedData: Data?
 
     override func setUp() {

--- a/StockBarTests/YahooFinanceDecoderTests.swift
+++ b/StockBarTests/YahooFinanceDecoderTests.swift
@@ -138,48 +138,4 @@ final class YahooFinanceDecoderTests: XCTestCase {
         XCTAssertEqual(quote.chart?.result?[1].meta.symbol, "GOOG")
     }
 
-    // MARK: - Meta Formatting
-
-    func testMetaPriceFormat() throws {
-        let meta = try makeMeta(price: 150.25, prevClose: 148.50, currency: "USD")
-        XCTAssertEqual(meta.getPrice(), "USD 150.25")
-    }
-
-    func testMetaChangePositive() throws {
-        let meta = try makeMeta(price: 150.25, prevClose: 148.50, currency: "USD")
-        XCTAssertEqual(meta.getChange(), "+1.75")
-    }
-
-    func testMetaChangeNegative() throws {
-        let meta = try makeMeta(price: 146.50, prevClose: 148.50, currency: "USD")
-        XCTAssertEqual(meta.getChange(), "-2.00")
-    }
-
-    func testMetaChangePct() throws {
-        let meta = try makeMeta(price: 150.0, prevClose: 100.0, currency: "USD")
-        XCTAssertEqual(meta.getChangePct(), "+50.0000%")
-    }
-
-    func testMetaNilCurrencyFallback() throws {
-        let meta = try makeMeta(price: 100.0, prevClose: 99.0, currency: nil)
-        XCTAssertTrue(meta.getPrice().hasPrefix("Price"))
-    }
-
-    // MARK: - Helpers
-
-    private func makeMeta(price: Double, prevClose: Double, currency: String?) throws -> Meta {
-        var jsonDict: [String: Any] = [
-            "symbol": "TEST",
-            "shortName": "Test",
-            "regularMarketTime": 1679000000,
-            "exchangeTimezoneName": "America/New_York",
-            "regularMarketPrice": price,
-            "chartPreviousClose": prevClose
-        ]
-        if let currency = currency {
-            jsonDict["currency"] = currency
-        }
-        let data = try JSONSerialization.data(withJSONObject: jsonDict)
-        return try JSONDecoder().decode(Meta.self, from: data)
-    }
 }


### PR DESCRIPTION
## Summary

### Structural refactoring
- **StockStatusBar**: stop subclassing `NSStatusBar`, use composition instead
- **P&L functions**: move from `SymbolMenu.swift` (UI) to `Trade.swift` (data layer)
- **Meta**: remove 5 dead formatting methods that duplicated `TradingInfo`

### Bug fixes
- **`struct Error` → `ChartError`**: was shadowing Swift's `Error` protocol
- **`try!` → `do/catch`** in `saveNewPrefs()`: prevents crash on encode failure
- **Division by zero guard** in `getChangePct()`: returns `+0.0000%` instead of `+inf%`
- **`mainStatusItem`** changed from optional to non-optional `let` (never nil)
- **Remove dead `emptyQueryURL`** with force-unwrap on unused code
- **Remove unnecessary `CodingKeys`** enum from `Meta` (matches property names)
- **Extract `"usertrades"` → `DataModel.userTradesKey`** constant (was duplicated in 2 files)

### Network traffic improvements
- **No API calls during typing**: removed `$trade` debounce merge from Combine pipeline
- **Refresh on preferences close**: fetches updated symbols when popover dismisses
- **Timer reset on refresh**: manual and timer-triggered refreshes no longer overlap
- **Immediate fetch on launch**: no more 60s wait for first data
- **`[weak self]` timer closure**: breaks retain cycle (was target/selector pattern)

### Tests
- Add 5 tests for `totalPNL`, `totalPositionCost`, `currentPositionValue`
- Remove 5 tests for deleted `Meta` formatting methods
- Update test references for `DataModel.userTradesKey`

## Test plan
- [x] All 36 tests pass locally via `xcodebuild test`
- [ ] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)