### PR TITLE
Add scheduled daily Yahoo Finance API live tests

### DIFF
--- a/.github/workflows/yahoo-api-live-tests.yml
+++ b/.github/workflows/yahoo-api-live-tests.yml
@@ -1,0 +1,113 @@
+name: Yahoo Finance API Live Tests
+
+on:
+  schedule:
+    # Run daily at 15:00 UTC (11:00 AM ET)
+    - cron: "0 15 * * *"
+  workflow_dispatch: # Allow manual triggers
+
+jobs:
+  live-api-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Yahoo Finance API Live Tests
+        id: test
+        run: |
+          max_attempts=3
+          attempt=1
+
+          while [ $attempt -le $max_attempts ]; do
+            echo "=== Attempt $attempt of $max_attempts ==="
+
+            xcodebuild test \
+              -project StockBar.xcodeproj \
+              -scheme StockBar \
+              -destination 'platform=macOS' \
+              -only-testing:StockBarTests/YahooFinanceAPITests \
+              -parallel-testing-enabled NO \
+              CODE_SIGN_IDENTITY="-" \
+              CODE_SIGNING_REQUIRED=NO \
+              CODE_SIGNING_ALLOWED=NO \
+              2>&1 | tee xcodebuild.log | xcpretty --color || true
+
+            result=${PIPESTATUS[0]}
+
+            if [ $result -eq 0 ]; then
+              echo "Tests passed on attempt $attempt"
+              exit 0
+            fi
+
+            echo "Attempt $attempt failed with exit code $result"
+            attempt=$((attempt + 1))
+
+            if [ $attempt -le $max_attempts ]; then
+              echo "Retrying in 30 seconds..."
+              sleep 30
+            fi
+          done
+
+          echo "All $max_attempts attempts failed"
+          exit 1
+
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcodebuild-log
+          path: xcodebuild.log
+          retention-days: 7
+
+  create-issue:
+    needs: live-api-tests
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Yahoo Finance API Live Tests Failed - ${new Date().toISOString().split('T')[0]}`;
+
+            // Avoid duplicate issues for the same day
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'api-test-failure',
+              per_page: 10,
+            });
+
+            if (issues.find(i => i.title === title)) {
+              console.log('Issue already exists for today, skipping.');
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: [
+                '## Yahoo Finance API Live Tests Failed',
+                '',
+                'All 3 retry attempts failed for the daily Yahoo Finance API live test suite.',
+                '',
+                `**Workflow run:** ${runUrl}`,
+                '',
+                '### Tests affected',
+                '- `testFetchRealStockQuote` — fetches AAPL quote',
+                '- `testFetchCurrencyPairQuote` — fetches USDJPY=X quote',
+                '- `testEndToEndRealTimeTradeWithLiveAPI` — end-to-end RealTimeTrade flow',
+                '',
+                '### Possible causes',
+                '- Yahoo Finance API endpoint changed or is down',
+                '- Rate limiting or IP blocking on GitHub Actions runners',
+                '- Response format changed (decoding failure)',
+                '',
+                `Check the [workflow run logs](${runUrl}) for details.`,
+              ].join('\n'),
+              labels: ['api-test-failure'],
+            });


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow that runs the 3 Yahoo Finance live API tests daily at 15:00 UTC (11:00 AM ET)
- Retries up to 3 times (with 30s delay) before reporting failure
- Automatically creates a GitHub issue labeled `api-test-failure` on failure, with deduplication to avoid duplicates per day

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` to verify it runs the correct test class
- [ ] Verify issue creation by simulating a failure (e.g., temporarily breaking the test)
- [ ] Confirm duplicate issue prevention works

🤖 Generated with [Claude Code](https://claude.com/claude-code)