### PR TITLE
Diff-based symbol item updates to preserve Command-drag ordering

### DIFF
--- a/StockBar/StockMenuBarController.swift
+++ b/StockBar/StockMenuBarController.swift
@@ -44,10 +44,7 @@ extension StockMenuBarController {
         self.statusBar.constructMainItemMenu(items: mainMenuItems)
     }
     private func updateSymbolItemsFromUserData(realTimeTrades: [RealTimeTrade]) {
-        statusBar.removeAllSymbolItems()
-        for iter in (0..<realTimeTrades.count) {
-            statusBar.constructSymbolItem(from: realTimeTrades[iter])
-        }
+        statusBar.updateSymbolItems(from: realTimeTrades)
     }
     // Trigger the quotes update for all symbols from URLSession.
     // This happens either when manually pressing the Refresh button

--- a/StockBar/StockStatusBar.swift
+++ b/StockBar/StockStatusBar.swift
@@ -10,7 +10,7 @@ import Cocoa
 
 class StockStatusBar {
     private let mainStatusItem: NSStatusItem
-    private var symbolStatusItems: [StockStatusItemController] = []
+    private var symbolStatusItems: [UUID: StockStatusItemController] = [:]
 
     init() {
         mainStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -23,11 +23,18 @@ class StockStatusBar {
         }
         mainStatusItem.menu = menu
     }
-    func removeAllSymbolItems() {
-        symbolStatusItems.removeAll()
-    }
-    func constructSymbolItem(from realTimeTrade : RealTimeTrade) {
-        symbolStatusItems.append(StockStatusItemController(realTimeTrade: realTimeTrade))
+    func updateSymbolItems(from realTimeTrades: [RealTimeTrade]) {
+        let newIDs = Set(realTimeTrades.map { $0.id })
+        let oldIDs = Set(symbolStatusItems.keys)
+
+        // Remove items that no longer exist
+        for id in oldIDs.subtracting(newIDs) {
+            symbolStatusItems.removeValue(forKey: id)
+        }
+        // Add items that are new
+        for trade in realTimeTrades where !oldIDs.contains(trade.id) {
+            symbolStatusItems[trade.id] = StockStatusItemController(realTimeTrade: trade)
+        }
     }
     func mainItem() -> NSStatusItem {
         return mainStatusItem


### PR DESCRIPTION
## Summary
- Replace remove-all/recreate-all pattern with UUID-keyed diff-based updates for status bar symbol items
- Only add/remove `NSStatusItem`s that actually changed, leaving existing ones untouched
- Preserves user's Command-drag menu bar positioning when preferences are modified

## Test plan
- [ ] Add a symbol in preferences — verify new item appears in menu bar
- [ ] Delete a symbol in preferences — verify only that item is removed
- [ ] Command-drag to reorder items, then add/delete a different symbol — verify existing items stay in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)